### PR TITLE
fix elasticsearch version

### DIFF
--- a/visual-image-search.ipynb
+++ b/visual-image-search.ipynb
@@ -43,7 +43,7 @@
     "!pip install tqdm\n",
     "\n",
     "#install necessary pkg to make connection with elasticsearch domain\n",
-    "!pip install elasticsearch\n",
+    "!pip install elasticsearch==7.13.0\n",
     "!pip install requests\n",
     "!pip install requests-aws4auth"
    ]


### PR DESCRIPTION
elasticsearch version>7.14 would not work with AWS


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
